### PR TITLE
Support scheduling compactions during time windows

### DIFF
--- a/test/exunit/scheduling_window_test.exs
+++ b/test/exunit/scheduling_window_test.exs
@@ -1,0 +1,81 @@
+defmodule SmooshSchedulingWindowTest do
+  use Couch.Test.ExUnit.Case
+
+  alias Couch.Test.Setup
+
+  setup_all(context) do
+    test_ctx = :test_util.start_couch([])
+
+    on_exit(fn ->
+      :config.delete('smoosh.test_channel', 'from')
+      :config.delete('smoosh.test_channel', 'to')
+      :test_util.stop_couch(test_ctx)
+    end)
+
+    context
+  end
+
+  test "in_allowed_window returns true by default", _context do
+    assert :smoosh_utils.in_allowed_window('nonexistent_channel') == true
+  end
+
+  test "in_allowed_window ignores bad input", _context do
+    :config.set('smoosh.test_channel', 'from', 'midnight', false)
+    :config.set('smoosh.test_channel', 'to', 'infinity', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == true
+  end
+
+  test "in_allowed_window returns false when now < from < to", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, 18_000)
+    to = DateTime.add(now, 36_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == false
+  end
+
+  test "in_allowed_window returns true when from < now < to", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, -18_000)
+    to = DateTime.add(now, 18_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == true
+  end
+
+  test "in_allowed_window returns false when from < to < now", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, -36_000)
+    to = DateTime.add(now, -18_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == false
+  end
+
+  test "in_allowed_window returns true when to < from < now", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, -18_000)
+    to = DateTime.add(now, -36_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == true
+  end
+
+  test "in_allowed_window returns false when to < now < from", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, 18_000)
+    to = DateTime.add(now, -18_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == false
+  end
+
+  test "in_allowed_window returns true when now < to < from", _context do
+    now = DateTime.utc_now()
+    from = DateTime.add(now, 36_000)
+    to = DateTime.add(now, 18_000)
+    :config.set('smoosh.test_channel', 'from', '#{from.hour}:#{from.minute}', false)
+    :config.set('smoosh.test_channel', 'to', '#{to.hour}:#{to.minute}', false)
+    assert :smoosh_utils.in_allowed_window('test_channel') == true
+  end
+end

--- a/test/exunit/test_helper.exs
+++ b/test/exunit/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+ExUnit.start()


### PR DESCRIPTION
This PR restores the CouchDB 2.x functionality of defining time windows during which compaction is allowed. It does this on a per-channel basis, e.g.

```
[smoosh.overnight_channel]
from = 20:00
to = 06:00
strict_window = true
```

The `strict_window` setting will cause smoosh to suspend all running compactions in this channel when leaving the window, rather than canceling them outright as in CouchDB 2.x.

I added some simple ExUnit tests on the window logic; the actual suspend / resume logic mostly uses existing Smoosh functionality and adds a self-addressed message once a minute to check if the channel is still operating in an allowed window.